### PR TITLE
include only source file

### DIFF
--- a/MomoiOSSwiftSdk.podspec
+++ b/MomoiOSSwiftSdk.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
   #
 
   s.source       = { :git => "https://github.com/momodevelopment/MomoiOSSwiftSdk.git", :tag => "2.0.0" }
-  s.source_files  = "MomoiOSSwiftSdk", "**/*"
+  s.source_files  = "MomoiOSSwiftSdk", "**/*.{h,mm,swift}"
   #s.exclude_files = "Classes/Exclude"
 
   # s.public_header_files = "Classes/**/*.h"


### PR DESCRIPTION
Change this to exclude "Info.plist" issue with xcode 10
Make pod-spec more standard
More information:
https://stackoverflow.com/questions/50718018/xcode-10-error-multiple-commands-produce